### PR TITLE
Adding a solr:create rake task

### DIFF
--- a/lib/solr_wrapper/tasks/solr_wrapper.rake
+++ b/lib/solr_wrapper/tasks/solr_wrapper.rake
@@ -32,6 +32,21 @@ namespace :solr do
     end
   end
 
+  desc 'Create a collection in solr'
+  task create: :start do
+    start = ARGV.find_index('solr:create')
+    if ARGV.length >= start + 2
+      directory = ARGV[start + 1]
+      name      = ARGV[start + 2]
+      # Rake tries to run these as tasks.
+      task(directory.to_sym) {}
+      task(name.to_sym) {}
+      @solr_instance.create dir: directory, name: name
+    else
+      raise "Usage: rake solr:create <directory> <name>"
+    end
+  end
+
   desc 'restart solr'
   task restart: :environment do
     puts "Restarting solr"

--- a/lib/solr_wrapper/tasks/solr_wrapper.rake
+++ b/lib/solr_wrapper/tasks/solr_wrapper.rake
@@ -32,18 +32,20 @@ namespace :solr do
     end
   end
 
-  desc 'Create a collection in solr'
-  task create: :start do
-    start = ARGV.find_index('solr:create')
-    if ARGV.length >= start + 2
-      directory = ARGV[start + 1]
-      name      = ARGV[start + 2]
-      # Rake tries to run these as tasks.
-      task(directory.to_sym) {}
-      task(name.to_sym) {}
-      @solr_instance.create dir: directory, name: name
-    else
-      raise "Usage: rake solr:create <directory> <name>"
+  namespace :collection do
+    desc 'Create a collection in solr'
+    task create: :start do
+      start = ARGV.find_index('solr:collection:create')
+      if ARGV.length >= start + 2
+        dir  = ARGV[start + 1]
+        name = ARGV[start + 2]
+        # Rake tries to run these as tasks.
+        task(dir.to_sym) {}
+        task(name.to_sym) {}
+        @solr_instance.create(dir: dir, name: name)
+      else
+        $stderr.puts "Usage: rake solr:collection:create <directory> <name>"
+      end
     end
   end
 


### PR DESCRIPTION
It looks like there aren't many good options for parsing arguments in rake.
This produces the cleanest command line invocation:
```bash
rake solr:create <directory> <name>
```