### PR TITLE
SolrWrapper.instance does not require any arguments

### DIFF
--- a/lib/solr_wrapper.rb
+++ b/lib/solr_wrapper.rb
@@ -29,7 +29,7 @@ module SolrWrapper
     @default_instance ||= instance(default_instance_options)
   end
 
-  def self.instance(options)
+  def self.instance(options = {})
     SolrWrapper::Instance.new(options)
   end
 

--- a/spec/lib/solr_wrapper_spec.rb
+++ b/spec/lib/solr_wrapper_spec.rb
@@ -13,6 +13,14 @@ describe SolrWrapper do
     end
   end
 
+  describe '.instance' do
+    context 'without arguments' do
+      it 'inherits the defaults' do
+        expect(SolrWrapper.instance.port).to eq '8983'
+      end
+    end
+  end
+
   describe ".default_instance_options=" do
     it "sets default options" do
       SolrWrapper.default_instance_options = { port: '1234' }


### PR DESCRIPTION
Fixes #42