### PR TITLE
Bump default solr version to 6.0.1

### DIFF
--- a/lib/solr_wrapper.rb
+++ b/lib/solr_wrapper.rb
@@ -7,7 +7,7 @@ require 'solr_wrapper/instance'
 
 module SolrWrapper
   def self.default_solr_version
-    '6.0.0'
+    '6.0.1'
   end
 
   def self.default_solr_port

--- a/spec/lib/solr_wrapper/instance_spec.rb
+++ b/spec/lib/solr_wrapper/instance_spec.rb
@@ -123,7 +123,7 @@ describe SolrWrapper::Instance do
 
   describe "#version" do
     subject { solr_instance.version }
-    it { is_expected.to eq '6.0.0' }
+    it { is_expected.to eq '6.0.1' }
   end
 
   describe "#md5" do


### PR DESCRIPTION
Apache remove 6.0.0 from the mirrors, so the downloads will fail with a 404.
