### PR TITLE
Fix SolrWrapper::Configuration#default_download_dir when not running …

### DIFF
--- a/lib/solr_wrapper/configuration.rb
+++ b/lib/solr_wrapper/configuration.rb
@@ -55,7 +55,7 @@ module SolrWrapper
     end
 
     def default_download_dir
-      if defined?(Rails) && Rails.root
+      if defined?(Rails) && Rails.respond_to?(:root) && Rails.root
         File.join(Rails.root, 'tmp')
       else
         Dir.tmpdir


### PR DESCRIPTION
…in a full rails environment

Fixes https://github.com/cbeer/engine_cart/issues/57