### PR TITLE
Improve compatibility with Foreman

### DIFF
--- a/exe/solr_wrapper
+++ b/exe/solr_wrapper
@@ -111,6 +111,8 @@ instance.wrap do |conn|
     begin
       conn.wait
     rescue Interrupt
+      Signal.trap("SIGTERM") {"IGNORE"}
+      Signal.trap("SIGINT") {"IGNORE"}
       $stderr.puts "Solr is shutting down."
     end
   end


### PR DESCRIPTION
Fixes #70 

Foreman shuts down processes by responding to a SIGINT on the master process and then sending SIGTERM signals to its child processes. solr_wrapper responds to the initial SIGINT, but can be killed by the following SIGTERM before it has had a chance to shut down the Solr instance.

This PR traps INT and TERM signals after the first Interrupt exception in handled, waiting for Solr to stop before exiting. solr_wrapper can still be KILLed with a kill -9.