### PR TITLE
Fix url for the md5 file download.

### DIFF
--- a/lib/solr_wrapper/settings.rb
+++ b/lib/solr_wrapper/settings.rb
@@ -77,7 +77,7 @@ module SolrWrapper
       if default_download_url == archive_download_url
         "#{archive_download_url}.md5"
       else
-        "http://www.us.apache.org/dist/lucene/solr/#{static_config.version}/solr-#{static_config.version}.zip.md5"
+        "https://archive.apache.org/dist/lucene/solr/#{static_config.version}/solr-#{static_config.version}.zip.md5"
       end
     end
 


### PR DESCRIPTION
It appears the default url was updated for the primary solr content
download but wasn't for the md5 portion of the script. Essentially
this fixes a bug of the following when trying this library:

> solr_wrapper -p 8983
Starting Solr 6.1.0 on port 8983 ...                                                                                                              /home/bluewolf/.rvm/gems/ruby-2.2.1/gems/solr_wrapper-0.15.0/lib/solr_wrapper/downloader.rb:11:in `rescue in fetch_with_progressbar': Unable to download solr from http://www.us.apache.org/dist/lucene/solr/6.1.0/solr-6.1.0.zip.md5 (SolrWrapper::SolrWrapperError)
404 Not Found
	from /home/bluewolf/.rvm/gems/ruby-2.2.1/gems/solr_wrapper-0.15.0/lib/solr_wrapper/downloader.rb:6:in `fetch_with_progressbar'
	from /home/bluewolf/.rvm/gems/ruby-2.2.1/gems/solr_wrapper-0.15.0/lib/solr_wrapper/md5.rb:37:in `md5file'
	from /home/bluewolf/.rvm/gems/ruby-2.2.1/gems/solr_wrapper-0.15.0/lib/solr_wrapper/md5.rb:32:in `read_file'
	from /home/bluewolf/.rvm/gems/ruby-2.2.1/gems/solr_wrapper-0.15.0/lib/solr_wrapper/md5.rb:28:in `expected_sum'
	from /home/bluewolf/.rvm/gems/ruby-2.2.1/gems/solr_wrapper-0.15.0/lib/solr_wrapper/md5.rb:15:in `validate?'
	from /home/bluewolf/.rvm/gems/ruby-2.2.1/gems/solr_wrapper-0.15.0/lib/solr_wrapper/instance.rb:292:in `download'
	from /home/bluewolf/.rvm/gems/ruby-2.2.1/gems/solr_wrapper-0.15.0/lib/solr_wrapper/instance.rb:254:in `extract'
	from /home/bluewolf/.rvm/gems/ruby-2.2.1/gems/solr_wrapper-0.15.0/lib/solr_wrapper/instance.rb:243:in `extract_and_configure'
	from /home/bluewolf/.rvm/gems/ruby-2.2.1/gems/solr_wrapper-0.15.0/lib/solr_wrapper/instance.rb:62:in `wrap'
	from /home/bluewolf/.rvm/gems/ruby-2.2.1/gems/solr_wrapper-0.15.0/exe/solr_wrapper:108:in `<top (required)>'
	from /home/bluewolf/.rvm/gems/ruby-2.2.1/bin/solr_wrapper:23:in `load'
	from /home/bluewolf/.rvm/gems/ruby-2.2.1/bin/solr_wrapper:23:in `<main>'
	from /home/bluewolf/.rvm/gems/ruby-2.2.1/bin/ruby_executable_hooks:15:in `eval'
	from /home/bluewolf/.rvm/gems/ruby-2.2.1/bin/ruby_executable_hooks:15:in `<main>'