### PR TITLE
Fixes cheksum failure when :md5sum option is a URL.

### DIFF
--- a/lib/solr_wrapper/downloader.rb
+++ b/lib/solr_wrapper/downloader.rb
@@ -13,7 +13,7 @@ module SolrWrapper
 
     class SafeProgressBar < ProgressBar::Base
       def progress=(new_progress)
-        self.total = new_progress if total <= new_progress
+        self.total = new_progress if !total.nil? && total <= new_progress
         super
       end
 

--- a/lib/solr_wrapper/settings.rb
+++ b/lib/solr_wrapper/settings.rb
@@ -74,10 +74,18 @@ module SolrWrapper
     end
 
     def md5url
-      if default_download_url == archive_download_url
+      if static_config.md5sum =~ URI::regexp
+        static_config.md5sum
+      elsif default_download_url == archive_download_url
         "#{archive_download_url}.md5"
       else
         "http://www.us.apache.org/dist/lucene/solr/#{static_config.version}/solr-#{static_config.version}.zip.md5"
+      end
+    end
+
+    def md5sum
+      if static_config.md5sum && static_config.md5sum.match(/^[a-f0-9]{32}$/)
+        static_config.md5sum
       end
     end
 

--- a/spec/lib/solr_wrapper/md5_spec.rb
+++ b/spec/lib/solr_wrapper/md5_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+
+describe SolrWrapper::MD5 do
+  let(:options) { { md5sum: md5sum } }
+  let(:solr_instance) { SolrWrapper::Instance.new(options) }
+  subject { solr_instance.md5 }
+
+  describe "#expected_sum" do
+    context ":md5sum option is an acual sum" do
+      let(:md5sum) { "0123456789abcdef0123456789abcdef" }
+
+      it "returns passed in md5sum" do
+        expect(subject.send(:expected_sum)).to eq(md5sum)
+      end
+    end
+
+    context ":md5sum options is a URL to a file containing the md5sum" do
+      url = "http://www.foobar.com/solr.zip.md5"
+      let(:md5sum) { url }
+
+      it "returns md5sum from URL" do
+        md5 = "fedcba9876543210fedcba9876543210"
+        File.open("/tmp/www-foobar-com.solr.md5", "w") { |f| f.puts md5 }
+
+        stub_request(:any, url).
+          to_return(body: File.new('/tmp/www-foobar-com.solr.md5'), status: 200)
+
+        expect(subject.send(:expected_sum)).to eq(md5)
+      end
+    end
+
+    context ":md5sum option is not set" do
+      let(:options) { {} }
+
+      it "returns md5sum from default md5url" do
+        expect(subject.send(:expected_sum)).to match(/^[a-f0-9]{32}$/)
+      end
+    end
+  end
+end


### PR DESCRIPTION
According to the current docs `md5sum` is either a path or URL to a file 
containing an md5sum.

When the `md5sum` is a URL either it is treated as an md5sum string failing
checksum test (because it's a URL) or it is not used and default md5sum url for
the default mirror is used instead.  In either case there is a check sum failure.

This commit fixes that issue by overriing the default md5url when `md5sum`
is a url.