### PR TITLE
Travis: Update the CI matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: ruby
-sudo: false
+
 rvm:
-  - 2.5.0
-  - 2.4.2
-  - 2.3.6
-  - jruby-9.1.16.0
+  - 2.5.3
+  - 2.4.5
+  - 2.3.8
+  - jruby-9.2.5.0
 
 jdk:
   - oraclejdk8


### PR DESCRIPTION

This PR only updates the CI matrix to the latest generally available Ruby versions.

Source for version numbers: https://github.com/rvm/rvm/blob/master/config/known

  - drop the non-functional "sudo: false"
  - use the newest versions from rvm