### PR TITLE
fix suggested log location for further information

### DIFF
--- a/lib/solr_wrapper/instance.rb
+++ b/lib/solr_wrapper/instance.rb
@@ -318,7 +318,7 @@ module SolrWrapper
       exit_status = runner.run(stringio)
 
       if exit_status != 0 && cmd != 'status'
-        raise "Failed to execute solr #{cmd}: #{stringio.read}. Further information may be available in #{instance_dir}/logs"
+        raise "Failed to execute solr #{cmd}: #{stringio.read}. Further information may be available in #{instance_dir}/server/logs"
       end
 
       stringio


### PR DESCRIPTION
I found my logs in #{instance_dir}/server/logs, not #{instance_dir}/logs. Better suggestion in error message will be less confusing and save yak shaving debugging time.