### PR TITLE
Adding `solr_wrapper --debug` option

### DIFF
--- a/exe/solr_wrapper
+++ b/exe/solr_wrapper
@@ -67,6 +67,10 @@ args = OptionParser.new do |opts|
     options[:ignore_checksum] = true
   end
 
+  opts.on("--debug", "Output configuration parameters and exit") do |d|
+    options[:debug] = true
+  end
+
   opts.separator ""
   opts.separator subtext
 end
@@ -97,6 +101,11 @@ rescue => error
 end
 
 instance = SolrWrapper.instance(options)
+
+if instance.debug?
+  puts instance.as_json
+  exit(0)
+end
 
 case command
 when 'clean'

--- a/lib/solr_wrapper/configuration.rb
+++ b/lib/solr_wrapper/configuration.rb
@@ -7,8 +7,11 @@ module SolrWrapper
     def initialize(options = {})
       @config = options[:config]
       @verbose = options[:verbose]
-
       @options = load_configs(Array(options[:config])).merge(options)
+    end
+
+    def debug?
+      @debug
     end
 
     def solr_xml

--- a/lib/solr_wrapper/instance.rb
+++ b/lib/solr_wrapper/instance.rb
@@ -35,7 +35,16 @@ module SolrWrapper
     # @option options [Hash] :env
     # @option options [String] :config
     def initialize(options = {})
+      @debug = options.fetch(:debug, false)
       @config = Settings.new(Configuration.new(options))
+    end
+
+    def debug?
+      @debug
+    end
+
+    def as_json
+      config.as_json
     end
 
     def host

--- a/lib/solr_wrapper/settings.rb
+++ b/lib/solr_wrapper/settings.rb
@@ -20,6 +20,25 @@ module SolrWrapper
       @static_config = static_config
     end
 
+    def as_json
+      {
+        host: host,
+        zookeeper_host: zookeeper_host,
+        port: port,
+        zookeeper_port: zookeeper_port,
+        url: url,
+        instance_dir: instance_dir,
+        managed: managed?,
+        download_url: download_url,
+        download_dir: download_dir,
+        solr_zip_path: solr_zip_path,
+        version_file: version_file,
+        solr_binary: solr_binary,
+        tmp_save_dir: tmp_save_dir,
+        default_download_url: default_download_url
+      }
+    end
+
     ##
     # Get the host this Solr instance is bound to
     def host


### PR DESCRIPTION
Prior to this commit, it was somewhat opaque what was used in the Solr
Wrapper work. This change will provide a way to gain insight into the
configuration options that would run.