### PR TITLE
Add --print_config command line parameter to dump the effective confi…

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ SolrWrapper.wrap port: 8983,
 | solr_options  | (Hash) |
 | env           | (Hash) |
 | persist      | (Boolean) Preserves the data in you collection between startups |
-
+| print_config  | (boolean) |
 ```ruby
 solr.with_collection(name: 'collection_name', dir: 'path_to_solr_configs')
 ```

--- a/exe/solr_wrapper
+++ b/exe/solr_wrapper
@@ -19,6 +19,10 @@ args = OptionParser.new do |opts|
     options[:verbose] = v
   end
 
+  opts.on("--print-config", "Print the configuration parameters") do |d|
+    options[:print_config] = true
+  end
+
   opts.on("--config FILE", "Load configuration from a file") do |v|
     options[:config] = v
   end
@@ -97,6 +101,12 @@ rescue => error
 end
 
 instance = SolrWrapper.instance(options)
+
+if options[:print_config]
+  $stderr.puts '### solr_wrapper configuration ###'
+  $stderr.puts instance.config.to_yaml
+  $stderr.puts '#####'
+end
 
 case command
 when 'clean'

--- a/lib/solr_wrapper/configuration.rb
+++ b/lib/solr_wrapper/configuration.rb
@@ -150,6 +150,10 @@ module SolrWrapper
       options.fetch(:poll_interval, 1)
     end
 
+    def tmp_save_dir
+      options[:tmp_save_dir]
+    end
+
     private
 
       def self.slice(source, *keys)

--- a/lib/solr_wrapper/settings.rb
+++ b/lib/solr_wrapper/settings.rb
@@ -20,6 +20,25 @@ module SolrWrapper
       @static_config = static_config
     end
 
+    def to_yaml(*args)
+      static_config.options.merge({
+        version: version,
+        verbose: verbose?,
+        download_dir: download_dir,
+        host: host,
+        zookeeper_host: zookeeper_host,
+        port: port,
+        zookeeper_port: zookeeper_port,
+        url: url,
+        instance_dir: instance_dir,
+        download_url: download_url,
+        solr_zip_path: solr_zip_path,
+        version_file: version_file,
+        mirror_url: default_download_url.gsub(%r{/lucene/solr.*}, ''),
+        tmp_save_dir: tmp_save_dir
+      }).to_yaml(*args)
+    end
+
     ##
     # Get the host this Solr instance is bound to
     def host
@@ -27,7 +46,7 @@ module SolrWrapper
     end
 
     def zookeeper_host
-      @zookeeper_host ||= static_config.zookeeper_port
+      @zookeeper_host ||= static_config.zookeeper_host
       @zookeeper_host ||= host
     end
 
@@ -77,6 +96,7 @@ module SolrWrapper
     end
 
     def tmp_save_dir
+      @tmp_save_dir ||= static_config.tmp_save_dir
       @tmp_save_dir ||= Dir.mktmpdir
     end
 


### PR DESCRIPTION
…guration to the console.

```
### solr_wrapper configuration ###
---
:download_dir: "/Users/cabeer/tmp"
:print_config: true
:version: 8.5.0
:verbose: false
:host: 127.0.0.1
:zookeeper_host: 127.0.0.1
:port: '8983'
:zookeeper_port: '9983'
:url: http://127.0.0.1:8983/solr/
:instance_dir: "/var/folders/58/71c4h5hs1nqg4780k242fmhw0000gq/T/solr-8.5.0"
:download_url: https://mirror.olnevhost.net/pub/apache/lucene/solr/8.5.0/solr-8.5.0.zip
:solr_zip_path: "/Users/cabeer/tmp/solr-8.5.0.zip"
:version_file: "/var/folders/58/71c4h5hs1nqg4780k242fmhw0000gq/T/solr-8.5.0/VERSION"
:mirror_url: https://mirror.olnevhost.net/pub/apache
:tmp_save_dir: "/var/folders/58/71c4h5hs1nqg4780k242fmhw0000gq/T/d20200409-97361-1rdbycr"
#####
```