### PR TITLE
Avoid warning from ruby interpreter on ampersand argument prefix

### DIFF
--- a/lib/solr_wrapper.rb
+++ b/lib/solr_wrapper.rb
@@ -40,7 +40,7 @@ module SolrWrapper
   ##
   # Ensures a Solr service is running before executing the block
   def self.wrap(options = {}, &block)
-    instance(options).wrap &block
+    instance(options).wrap(&block)
   end
 
   class SolrWrapperError < StandardError; end


### PR DESCRIPTION
Avoids this warning being issued:

```
solr_wrapper-3.1.2/lib/solr_wrapper.rb:43: warning: `&' interpreted as argument prefix
```
