### PR TITLE
Upgrade the rake spec

### DIFF
--- a/solr_wrapper.gemspec
+++ b/solr_wrapper.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "retriable"
 
   spec.add_development_dependency "bundler", ">= 1.7", "< 3"
-  spec.add_development_dependency "rake", "~> 10.0", "< 13"
+  spec.add_development_dependency "rake", ">= 12.2", "< 14"
 
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "simple_solr_client", "= 0.2.0" # 0.2.1 removed support for schema retrieval


### PR DESCRIPTION
 Rake 10 does not work with ruby 3.2:
```
 NoMethodError: undefined method `=~' for #<Proc:0x000000010b968a50 /Users/jcoyne85/.rbenv/versions/3.2.1/lib/ruby/gems/3.2.0/gems/rake-10.5.0/lib/rake/application.rb:393 (lambda)>
```