### PR TITLE
Update the required faraday version

### DIFF
--- a/solr_wrapper.gemspec
+++ b/solr_wrapper.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "faraday"
+  spec.add_dependency "faraday", "~> 2.5"
   spec.add_dependency "faraday-follow_redirects"
   spec.add_dependency "minitar"
   spec.add_dependency "ruby-progressbar"


### PR DESCRIPTION
The streaming API we use was introduced in 2.5. https://github.com/lostisland/faraday/commit/6799f5852d31dae32699949790633c68282ab71d