### PR TITLE
Fix Solr 9.7 :dir option handling

### DIFF
--- a/lib/solr_wrapper/instance.rb
+++ b/lib/solr_wrapper/instance.rb
@@ -159,6 +159,11 @@ module SolrWrapper
         create_options[:n] = options[:config_name] if options[:config_name]
 
         if options[:dir]
+          # Turn a relative path to absolute. Solr 9.7+ changes relative to be
+          # relative to solr instance dir (which can be a temp dir for us),
+          # instead of command CWD. Normalize to absolute is good for all.
+          options[:dir] = File.expand_path(".", options[:dir])
+
           # Solr 9.7 required that the dir argument contain a `conf` directory that
           # contains the actual configuration files.
           if version >= '9.7' && !File.exist?(File.join(options[:dir], 'conf'))

--- a/lib/solr_wrapper/instance.rb
+++ b/lib/solr_wrapper/instance.rb
@@ -162,7 +162,7 @@ module SolrWrapper
           # Turn a relative path to absolute. Solr 9.7+ changes relative to be
           # relative to solr instance dir (which can be a temp dir for us),
           # instead of command CWD. Normalize to absolute is good for all.
-          options[:dir] = File.expand_path(".", options[:dir])
+          options[:dir] = File.absolute_path(options[:dir])
 
           # Solr 9.7 required that the dir argument contain a `conf` directory that
           # contains the actual configuration files.

--- a/lib/solr_wrapper/instance.rb
+++ b/lib/solr_wrapper/instance.rb
@@ -167,9 +167,9 @@ module SolrWrapper
           # Solr 9.7 required that the dir argument contain a `conf` directory that
           # contains the actual configuration files.
           if version >= '9.7' && !File.exist?(File.join(options[:dir], 'conf'))
-
-            if options[:dir].match?(/conf\/$/)
-              create_options[:d] = File.expand_path(options[:dir], '..')
+            # ends in `conf` or `conf/`
+            if options[:dir].match?(/conf\/?$/)
+              create_options[:d] = File.expand_path("..", options[:dir])
             else
               tmpdir = Dir.mktmpdir
 


### PR DESCRIPTION
Some fixes were introduced in 608d677 to try to keep `options[:dir]` working with Solr 9.7, but they contained a bug, and also failed to make *relative* paths working, which were working before.  

1. As of Solr 9.7 the `-d` option to `solr` command line, if a relative path, is relative to Solr instance dir instead of to CWD of the process executring `solr`.  There's no great way to make that semantics work even if we wanted to, but instead we expand to absolute path before passing to `solr`, to keep `solr_wrapper` behavior the same with Solr pre or post 9.7

2. The attempt to recognize a :dir set directly to `conf/` and fix it to go up one directory failed because the arguments to `File.expand_path` were reversed from what they should be. 

3. The attempt to recognize a :dir ending in `conf/` started requiring a trailing `/`, which :dir didn't before and which is a gotcha, normally with or without trailing `/` is the same, and now it is again. 

- normalize :dir option to absolute path, for consistent handling in any solr version
- Fix attempt to handle dir to conf, go up one dir right way and do not require trailing /

Tested in solr 8.11, 9.6.1, and 9.8.1:  With relative and absolute paths in `dir:` option in `.solr_wrapper.yml`, set to both parent `/solr` dir containing `conf/`, as well as to `solr/conf`.  Working in all of them. 